### PR TITLE
Add Kayobe ansible var symlinks to allow drop-in use of repo

### DIFF
--- a/filter_plugins
+++ b/filter_plugins
@@ -1,0 +1,1 @@
+../../../../kayobe/ansible/filter_plugins/

--- a/group_vars
+++ b/group_vars
@@ -1,0 +1,1 @@
+../../../../kayobe/ansible/group_vars/

--- a/test_plugins
+++ b/test_plugins
@@ -1,0 +1,1 @@
+../../../../kayobe/ansible/test_plugins/


### PR DESCRIPTION
Allows this repo to be used as the basis for a kayobe custom playbook directory. (See https://docs.openstack.org/kayobe/latest/custom-ansible-playbooks.html#packaging-custom-playbooks-with-configuration for details)