### PR TITLE
Improve detecting if nested virtualisation is enabled

### DIFF
--- a/nested_kvm.yml
+++ b/nested_kvm.yml
@@ -37,7 +37,7 @@
       shell: "cat /sys/module/kvm_intel/parameters/nested"
       changed_when: false
       register: result
-      failed_when: "'Y' not in result.stdout_lines"
+      failed_when: "'Y' not in result.stdout_lines or '1' not in result.stdout_lines"
     - name: Restart nova_libvirt container
       shell: "docker restart nova_libvirt"
-    when: "kvm.rc != 0 or 'Y' not in nested.stdout_lines"
+    when: "kvm.rc != 0 or ('Y' not in nested.stdout_lines or '1' not in nested.stdout_lines)"

--- a/nested_kvm.yml
+++ b/nested_kvm.yml
@@ -40,4 +40,4 @@
       failed_when: "'Y' not in result.stdout_lines and '1' not in result.stdout_lines"
     - name: Restart nova_libvirt container
       shell: "docker restart nova_libvirt"
-    when: "kvm.rc != 0 or ('Y' not in nested.stdout_lines or '1' not in nested.stdout_lines)"
+    when: "kvm.rc != 0 or ('Y' not in nested.stdout_lines and '1' not in nested.stdout_lines)"

--- a/nested_kvm.yml
+++ b/nested_kvm.yml
@@ -37,7 +37,7 @@
       shell: "cat /sys/module/kvm_intel/parameters/nested"
       changed_when: false
       register: result
-      failed_when: "'Y' not in result.stdout_lines or '1' not in result.stdout_lines"
+      failed_when: "'Y' not in result.stdout_lines and '1' not in result.stdout_lines"
     - name: Restart nova_libvirt container
       shell: "docker restart nova_libvirt"
     when: "kvm.rc != 0 or ('Y' not in nested.stdout_lines or '1' not in nested.stdout_lines)"


### PR DESCRIPTION
Current CentOS and Ubuntu distributions return `0` or `1` from sysfs nested virt info.