### PR TITLE
VF-LAG toolkit

### DIFF
--- a/files/mlnx-vflag-early
+++ b/files/mlnx-vflag-early
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+[ -f /etc/sysconfig/sriov ] && source /etc/sysconfig/sriov
+
+# Defaults
+
+# The network devices on which we create VFs.
+SRIOV_PFS=${SRIOV_PFS:-"ens3f0 ens3f1"}
+
+# The number of VFs to create on each PF
+SRIOV_VF_COUNT=${SRIOV_VF_COUNT:-8}
+
+# The number of combined channels to enable on each PF
+SRIOV_PF_CHANNELS=${SRIOV_PF_CHANNELS:-63}
+
+# The number of combined channels to enable on each representor
+SRIOV_VF_CHANNELS=${SRIOV_VF_CHANNELS:-18}
+
+
+function sriov_vf_create
+{
+    PF_NIC=$1
+    VF_COUNT=$2
+
+    cd /sys/class/net/$PF_NIC/device
+    PF_PCI=pci/$(basename $(realpath $PWD))
+    logger -t mlnx-vflag-early "Creating $VF_COUNT VFs for $PF_NIC ($PF_PCI)"
+
+    echo $VF_COUNT > sriov_numvfs
+    for i in $(readlink virtfn*)
+    do
+	logger -t mlnx-vflag-early "Unbinding $(basename $i)"
+	echo $(basename $i) > /sys/bus/pci/drivers/mlx5_core/unbind
+    done
+
+    # Put the NIC eSwitch into devlink mode
+    devlink dev eswitch set $PF_PCI mode switchdev
+    logger -t mlnx-vflag-early "After enabling switchdev: $(devlink dev eswitch show $PF_PCI)"
+}
+
+function enable_tc_offload
+{
+    PF_NIC=$1
+    TC_OFFLOAD=$(ethtool -k $PF_NIC | awk '{print $2}')
+    if [[ "$TC_OFFLOAD" != "on" ]]
+    then
+	logger -t mlnx-vflag-early "Enabling HW TC offload for $PF_NIC"
+	ethtool -K $PF_NIC hw-tc-offload on
+    fi
+}
+
+function hwrep_ethtool
+{
+    # There isn't an obvious way to connect a representor port
+    # back to the PF or VF, so apply tuning to all representor ports
+    # served by the mlx5e_rep driver.
+    hwrep_devs=$(cd /sys/devices/virtual/net; for i in *
+    do
+	ethtool -i $i 2> /dev/null |
+            awk -v dev=$i '$1=="driver:" && $2=="mlx5e_rep" {print dev}'
+    done)
+
+    for i in $hwrep_devs
+    do
+        # Magic values provided by Mellanox engineering
+	logger -t mlnx-vflag-early "Tuning receive channels for representor $i"
+        ethtool -L $i combined $SRIOV_VF_CHANNELS
+
+	# Enable hardware TC offload for each representor device
+        enable_tc_offload $i
+    done
+}
+
+for PF in $SRIOV_PFS
+do
+    # Validate that the NIC exists as a network device
+    if [[ ! -d /sys/class/net/$PF ]]
+    then
+	logger -t mlnx-vflag-early "NIC $PF not found, aborting"
+	echo "mlnx-vflag-early: NIC $PF not found" >&2
+        exit -1
+    fi
+
+    # Validate that the NIC is not already up and active in a bond
+    # It appears this could be fatal.
+    dev_flags=$(ip link show dev $PF | grep -o '<.*>')
+    grep -q '\<SLAVE\>' <<< $dev_flags
+    if [[ $? -eq 0 ]]
+    then
+	logger -t mlnx-vflag-early "NIC $PF already part of a bond, aborting"
+	echo "mlnx-vflag-early: NIC $PF already part of a bond" >&2
+        exit -1
+    fi
+
+    sriov_vf_create $PF $SRIOV_VF_COUNT
+    enable_tc_offload $PF
+
+    # Raise the receive channels configured for this PF, if too low
+    logger -t mlnx-vflag-early "Tuning receive channels for PF $PF"
+    ethtool -L $PF combined $SRIOV_PF_CHANNELS
+done
+
+hwrep_ethtool
+

--- a/files/mlnx-vflag-early
+++ b/files/mlnx-vflag-early
@@ -100,5 +100,6 @@ do
     ethtool -L $PF combined $SRIOV_PF_CHANNELS
 done
 
+/sbin/udevadm settle --timeout=20
 hwrep_ethtool
 

--- a/files/mlnx-vflag-early
+++ b/files/mlnx-vflag-early
@@ -54,7 +54,7 @@ function hwrep_ethtool
     # There isn't an obvious way to connect a representor port
     # back to the PF or VF, so apply tuning to all representor ports
     # served by the mlx5e_rep driver.
-    hwrep_devs=$(cd /sys/devices/virtual/net; for i in *
+    hwrep_devs=$(cd /sys/class/net; for i in *
     do
 	ethtool -i $i 2> /dev/null |
             awk -v dev=$i '$1=="driver:" && $2=="mlx5e_rep" {print dev}'

--- a/files/mlnx-vflag-final
+++ b/files/mlnx-vflag-final
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+[ -f /etc/sysconfig/sriov ] && source /etc/sysconfig/sriov
+
+function sriov_vf_bind
+{
+    PF_NIC=$1
+    if [[ ! -d /sys/class/net/$PF_NIC ]]
+    then
+	logger -t mlnx-vflag-final "NIC $PF_NIC not found, aborting"
+	echo "mlnx-vflag-final: NIC $PF_NIC not found" >&2
+        exit -1
+    fi
+
+    # Validate that the NIC is configured to be part of a bond.
+    dev_flags=$(ip link show dev $PF_NIC | grep -o '<.*>')
+    grep -q '\<SLAVE\>' <<< $dev_flags
+    if [[ $? -ne 0 ]]
+    then
+	logger -t mlnx-vflag-final "NIC $PF_NIC not part of a bond, VF-LAG abort"
+	echo "mlnx-vflag-final: NIC $PF_NIC not part of a bond, VF-LAG abort" >&2
+        exit -1
+    fi
+
+    # It appears we need to rebind the VFs to NIC devices, and then
+    # attach the NIC devices to the OVS bridge to which our bond is attached.
+    cd /sys/class/net/$PF_NIC/device
+    PF_PCI=pci/$(basename $(realpath $PWD))
+    for i in $(readlink virtfn*)
+    do
+	logger -t mlnx-vflag-final "Binding $(basename $i)"
+	echo $(basename $i) > /sys/bus/pci/drivers/mlx5_core/bind
+    done
+}
+
+# The network devices on which we create VFs.
+SRIOV_PFS=${SRIOV_PFS:-"ens3f0 ens3f1"}
+
+for PF in $SRIOV_PFS
+do
+    sriov_vf_bind $PF
+done
+

--- a/templates/mlnx-vflag-early.service.j2
+++ b/templates/mlnx-vflag-early.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Early configuration for Mellanox SR-IOV and VF-LAG
+{% for nic in bond0_mgmt_bond_slaves %}
+Requires=sys-subsystem-net-devices-{{ nic }}.device
+After=sys-subsystem-net-devices-{{ nic }}.device
+{% endfor %}
+Requires=network-pre.target
+Before=network-pre.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/mlnx-vflag-early
+RemainAfterExit=yes
+
+[Install]
+WantedBy=network-pre.target

--- a/templates/mlnx-vflag-final.service.j2
+++ b/templates/mlnx-vflag-final.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description=Final configuration for Mellanox SR-IOV and VF-LAG
+Wants=network-online.target
+After=network-online.target
+Before=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/mlnx-vflag-final
+RemainAfterExit=yes
+
+[Install]
+WantedBy=docker.service

--- a/templates/sysconfig-sriov.j2
+++ b/templates/sysconfig-sriov.j2
@@ -1,0 +1,9 @@
+# The network devices on which we create VFs.
+SRIOV_PFS="{{ bond0_mgmt_bond_slaves | join(' ') }}"
+
+# The number of VFs to create on each PF.
+SRIOV_VF_COUNT=8
+
+# The name of the OVS bridge to which dangling SR-IOV VFs should be moored
+SRIOV_OVS_BRIDGE={{ bond0_mgmt_interface }}-ovs
+

--- a/vf-lag-host-configure.yml
+++ b/vf-lag-host-configure.yml
@@ -1,0 +1,60 @@
+---
+# This playbook should execute after kayobe overcloud host configure has completed.
+
+- name: Prepare hosts for VF-LAG support
+  hosts: compute-100G
+  tags:
+    - vflag
+  tasks:
+    # Write /etc/sysconfig/sriov configuration to match this host
+    - name: Define parameters in /etc/sysconfig/sriov
+      template:
+        src: "sysconfig-sriov.j2"
+        dest: "/etc/sysconfig/sriov"
+        owner: "root"
+        group: "root"
+        mode: 0755
+      become: true
+      notify: Reboot and wait
+
+    - name: Transfer VF-LAG helper scripts to /usr/local/bin
+      copy:
+        src: "{{ item }}"
+        dest: "/usr/local/bin/{{ item }}"
+        owner: "root"
+        group: "root"
+        mode: 0755
+      become: true
+      with_items:
+        - "mlnx-vflag-early"
+        - "mlnx-vflag-final"
+      notify: Reboot and wait
+
+    - name: Transfer VF-LAG systemd units to /etc/systemd/system
+      template:
+        src: "{{ item }}.j2"
+        dest: "/etc/systemd/system/{{ item }}"
+        owner: "root"
+        group: "root"
+        mode: 0644
+      become: true
+      with_items:
+        - "mlnx-vflag-early.service"
+        - "mlnx-vflag-final.service"
+      notify: Reboot and wait
+
+    - name: Enable VF-LAG systemd units
+      systemd:
+        daemon_reload: true
+        name: "{{ item }}"
+        enabled: true
+      become: true
+      with_items:
+        - "mlnx-vflag-early.service"
+        - "mlnx-vflag-final.service"
+      notify: Reboot and wait
+
+  handlers:
+    - name: Reboot and wait
+      include_tasks: tasks/reboot.yml
+      tags: reboot

--- a/vf-lag-service-deploy.yml
+++ b/vf-lag-service-deploy.yml
@@ -1,0 +1,44 @@
+---
+# This playbook should run after the OpenStack services have been deployed
+# It will restart OpenVswitch if the hardware offload needs to be enabled.
+
+- name: Prepare hosts for VF-LAG support
+  hosts: compute-100G
+  tags:
+    - vflag
+  vars:
+    ovs_container: "openvswitch_vswitchd"
+  tasks:
+    # Verify Open vSwitch is up and running
+    - name: Gather data on running conatiners
+      command: "docker ps --format '{%raw%}{{.Names}}{%endraw%}'"
+      register: docker_data
+      become: true
+      changed_when: false
+
+    - name: Check the openvswitch_vswitchd docker containers are running before proceeding
+      fail:
+        msg: "Open vSwitch container not detected on {{ ansible_hostname }}"
+      when: "ovs_container not in docker_data.stdout_lines"
+
+    # Enable hardware offload on OVS
+    - name: Read OVS configuration for hardware offload
+      command: "docker exec {{ ovs_container }} ovs-vsctl get Open_vSwitch . other_config:hw-offload"
+      register: ovs_offload_config
+      become: true
+      ignore_errors: yes
+      changed_when: false
+ 
+    - name: Configure OVS to enable hardware offload
+      command: "docker exec {{ ovs_container }} ovs-vsctl set Open_vSwitch . other_config:hw-offload=true"
+      become: true
+      when: "'\"true\"' not in ovs_offload_config.stdout_lines"
+      notify:
+        - Restart OVS
+
+  handlers:
+    - name: Restart OVS
+      command: "docker restart {{ ovs_container }}"
+      become: true
+
+...


### PR DESCRIPTION
Initial playbooks as shared with client early adopters
Fix for OFED 5.4's handling of representor port symlinks under /sys