### PR TITLE
Enable auto-configured block live migration

### DIFF
--- a/nova-compute-drain.yml
+++ b/nova-compute-drain.yml
@@ -31,6 +31,7 @@
         - name: Live migrate instances
           command: >
             {{ venv }}/bin/openstack
+            --os-compute-api-version 2.25
             server migrate
             {{ instance_uuid }}
             --live-migration


### PR DESCRIPTION
Starting from python-openstackclient 5.5.0, it is not necessary to
specify the --block-migration argument when instance disks are not on
shared storage [1]. Instead, we can request the use of Nova API version
2.25, which added the auto value for block_migration.

This was added to Mitaka so it is safe to use on all our deployments.

This client version is only available from Wallaby. On Victoria, the
change is a no-op.

Note that a warning will be written to stderr about --disk-overcommit
and --no-disk-overcommit options. This is a bug in openstackclient [2].

[1] https://review.opendev.org/c/openstack/python-openstackclient/+/771801
[2] https://storyboard.openstack.org/#!/story/2009657