### PR TITLE
Allow to serialise critical upgrade tasks

### DIFF
--- a/migrate-to-centos-stream.yml
+++ b/migrate-to-centos-stream.yml
@@ -17,6 +17,7 @@
 
 - name: Run dnf distro-sync
   hosts: seed-hypervisor:seed:overcloud:infra-vms
+  serial: "{{ lookup('env', 'ANSIBLE_SERIAL') | default(0) }}"
   tags:
     - migrate-to-centos-stream
   tasks:

--- a/reboot.yml
+++ b/reboot.yml
@@ -1,6 +1,7 @@
 ---
 - name: Reboot the host
   hosts: seed-hypervisor:seed:overcloud:infra-vms
+  serial: "{{ lookup('env', 'ANSIBLE_SERIAL') | default(0) }}"
   tags:
     - reboot
   tasks:

--- a/tools/migrate-to-centos-stream.sh
+++ b/tools/migrate-to-centos-stream.sh
@@ -12,6 +12,8 @@ fi
 
 PARENT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+export ANSIBLE_SERIAL=${ANSIBLE_SERIAL:-0}
+
 host=$1
 
 kayobe playbook run -vv $KAYOBE_CONFIG_PATH/ansible/migrate-to-centos-stream.yml --limit $host

--- a/tools/package-update-and-reboot.sh
+++ b/tools/package-update-and-reboot.sh
@@ -10,12 +10,15 @@ if [[ $# -ne 1 ]]; then
     exit 1
 fi
 
+export ANSIBLE_SERIAL=${ANSIBLE_SERIAL:-0}
+
 host=$1
 
 kayobe playbook run -vv $KAYOBE_CONFIG_PATH/ansible/nova-compute-disable.yml --limit $host
 
 kayobe playbook run -vv $KAYOBE_CONFIG_PATH/ansible/nova-compute-drain.yml --limit $host
 
+# FIXME(priteau): serial doesn't apply to Kayobe commands
 kayobe overcloud host package update --limit $host --packages "*"
 
 kayobe playbook run -vv $KAYOBE_CONFIG_PATH/ansible/reboot.yml --limit $host


### PR DESCRIPTION
Note that `kayobe overcloud host package update` doesn't support serial execution.