### PR TITLE
update wazuh to version 4.3.10

### DIFF
--- a/vars/wazuh-manager.yml
+++ b/vars/wazuh-manager.yml
@@ -1,88 +1,76 @@
 ---
-# Wazuh-Manager, Filebeat and Open Distro role configuration
-# Reference: https://documentation.wazuh.com/4.1/deploying-with-ansible/reference.html
-# Defaults:
-# - https://github.com/wazuh/wazuh-ansible/blob/v4.1.5/roles/opendistro/opendistro-elasticsearch/defaults/main.yml
-# - https://github.com/wazuh/wazuh-ansible/blob/v4.1.5/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
-# - https://github.com/wazuh/wazuh-ansible/blob/v4.1.5/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
-# - https://github.com/wazuh/wazuh-ansible/blob/v4.1.5/roles/opendistro/opendistro-kibana/defaults/main.yml
+# Wazuh deployment details and documetation:
+# https://documentation.wazuh.com/current/deployment-options/deploying-with-ansible/index.html
+#
+# Defaults that are modified by this file:
+# https://github.com/wazuh/wazuh-ansible/blob/4.3/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
+# https://github.com/wazuh/wazuh-ansible/blob/4.3/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
+# https://github.com/wazuh/wazuh-ansible/blob/4.3/roles/wazuh/wazuh-dashboard/defaults/main.yml
+# https://github.com/wazuh/wazuh-ansible/blob/4.3/roles/wazuh/wazuh-indexer/defaults/main.yml
+# https://github.com/wazuh/wazuh-ansible/blob/4.3/roles/wazuh/ansible-wazuh-manager/defaults/main.yml
 
-# Domain name used to generate Search Guard CE certificates
-domain_name: "wazuh.example.com"
 
 # Wazuh IP accessible from nodes running agents
 # Change network as needed
 wazuh_manager_ip: "{{ provision_oc_net_name | net_ip(inventory_hostname) }}"
 
-# Single node Open Distro setup
+# Single node setup
 single_node: true
 minimum_master_nodes: 1
 
-# All nodes are masters in a single node setup
-elasticsearch_node_master: true
 
-# Elasticsearch node.name
-# Also used in certificate file paths
-elasticsearch_node_name: "{{ inventory_hostname }}"
-
-# Elasticsearch network.host
-elasticsearch_network_host: "{{ wazuh_manager_ip }}"
-
-# Modify major versions at your own peril
-elastic_stack_version: "7.10.2"
-
-# Filebeat node name used for certificate file paths
-filebeat_node_name: "{{ elasticsearch_node_name }}"
-
-# Elasticsearch target for filebeat
-filebeat_output_elasticsearch_hosts: "{{ elasticsearch_network_host }}:9200"
-
-# Update role default 4.1.4-1 for vuln detector fix
-wazuh_manager_version: 4.1.5-1
-
-# Used for Search Guard tls config, dict key (wazuh) unused
-instances:
-  wazuh:
-    name: "{{ elasticsearch_node_name }}"
-    ip: "{{ wazuh_manager_ip }}"
+# Configure hostnames for Wazuh indexer nodes
+# Example es1.example.com, es2.example.com
+domain_name: "wazuh.the-dma.uk"
 
 # Ansible control host certificate directory
-local_certs_path: "{{ playbook_dir }}/vars/certificates"
+local_certs_path: "{{ playbook_dir }}/vars/certificates/"
 
-# Kibana node name used for certificate file paths
-kibana_node_name: "{{ elasticsearch_node_name }}"
+# Indexer variables
+indexer_node_name: "{{ inventory_hostname }}"
 
-# Used by agents to authenticate to the manager
-authd_pass: "{{ secrets_wazuh.authd_pass }}"
+# IP to which indexer will bind on host.
+indexer_network_host: "{{ provision_oc_net_name | net_ip(inventory_hostname) }}"
+
+# Even in a single node setup this must be defined. If not defaults to 127.0.0.1
+indexer_cluster_nodes:
+  - "{{ indexer_network_host }}"
+
+# Filebeat variables
+filebeat_node_name: "{{ indexer_node_name }}"
+
+filebeat_output_indexer_hosts: "{{ indexer_network_host }}:9200"
+
+# Dashboard variables
+dashboard_node_name: "{{ indexer_node_name }}"
+
+dashboard_server_host: "{{ indexer_network_host }}"
+
+dashboard_server_name: "{{ indexer_node_name }}"
+
+indexer_admin_password: "{{ secrets_wazuh.opendistro_admin_password }}"
+
+dashboard_user: kibanaserver
+
+# TODO refactor creation and usage of secrets_wazuh
+dashboard_password: "{{ secrets_wazuh.opendistro_kibana_password }}"
+
+# Indexer filebeat user
+indexer_security_user: admin
+
+# Indexer filebeat password
+indexer_security_password: "{{ secrets_wazuh.opendistro_admin_password }}"
 
 # Used to override the default Wazuh api user
 wazuh_api_users: "{{ secrets_wazuh.wazuh_api_users }}"
 
-# Kibana to Wazuh api credentials
+# Dashboard to Wazuh api credentials
 wazuh_api_credentials:
   - id: "default"
-    url: "https://localhost"
+    url: "https://{{ indexer_network_host }}"
     port: 55000
     username: "wazuh"
     password: "{{ secrets_wazuh.wazuh_api_users | selectattr('username', 'match', 'wazuh') | map(attribute='password') | first }}"
-
-# Open Distro admin user pass
-opendistro_admin_password: "{{ secrets_wazuh.opendistro_admin_password }}"
-
-# Open Distro kibana user
-# role default is admin
-opendistro_kibana_user: "kibanaserver"
-
-# Open Distro kibana user pass
-opendistro_kibana_password: "{{ secrets_wazuh.opendistro_kibana_password }}"
-
-# Open Distro filebeat user
-# Role default is admin
-# TODO: create filebeat user
-elasticsearch_security_user: "admin"
-
-# Open Distro filebeat user pass
-elasticsearch_security_password: "{{ secrets_wazuh.opendistro_admin_password }}"
 
 # Perform hash_behaviour=merge at role runtime
 wazuh_manager_config_overlay: true
@@ -102,6 +90,8 @@ wazuh_manager_email_notification: 'no'
 # Log format of /var/ossec/logs/ossec.{log|json}
 wazuh_manager_log_format: 'plain'
 
+authd_pass: "{{ secrets_wazuh.authd_pass }}"
+
 # Wazuh-Manager listener settings
 wazuh_manager_connection:
   - type: 'secure'
@@ -115,11 +105,13 @@ wazuh_manager_authd:
   enable: true
   port: 1515
   use_source_ip: 'no'
-  force_insert: 'no'
-  force_time: 0
+  force:
+    enabled: 'no'
+    key_mismatch: 'no'
+    disconnected_time: '0'
+    after_registration_time: '0'
   purge: 'no'
   use_password: 'yes'
-  limit_maxagents: 'yes'
   ciphers: 'HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH'
   ssl_agent_ca: null
   ssl_verify_host: 'no'

--- a/vars/wazuh-manager.yml
+++ b/vars/wazuh-manager.yml
@@ -17,7 +17,7 @@ wazuh_manager_ip: "{{ provision_oc_net_name | net_ip(inventory_hostname) }}"
 # Single node setup
 single_node: true
 minimum_master_nodes: 1
-
+indexer_node_master: true
 
 # Configure hostnames for Wazuh indexer nodes
 # Example es1.example.com, es2.example.com
@@ -35,6 +35,14 @@ indexer_network_host: "{{ provision_oc_net_name | net_ip(inventory_hostname) }}"
 # Even in a single node setup this must be defined. If not defaults to 127.0.0.1
 indexer_cluster_nodes:
   - "{{ indexer_network_host }}"
+
+instances:
+  node1:
+    name: "{{ indexer_node_name }}"       # Important: must be equal to indexer_node_name.
+    ip: "{{ indexer_network_host }}"
+    role: indexer
+
+ansible_shell_allow_world_readable_temp: true
 
 # Filebeat variables
 filebeat_node_name: "{{ indexer_node_name }}"

--- a/vars/wazuh-manager.yml
+++ b/vars/wazuh-manager.yml
@@ -21,7 +21,7 @@ minimum_master_nodes: 1
 
 # Configure hostnames for Wazuh indexer nodes
 # Example es1.example.com, es2.example.com
-domain_name: "wazuh.the-dma.uk"
+domain_name: "example.com"
 
 # Ansible control host certificate directory
 local_certs_path: "{{ playbook_dir }}/vars/certificates/"

--- a/wazuh-manager.yml
+++ b/wazuh-manager.yml
@@ -1,135 +1,67 @@
 ---
-- hosts: wazuh
-  become: yes
-  vars_files:
-    - "{{ playbook_dir }}/vars/wazuh-manager.yml"
-    - "{{ playbook_dir }}/vars/wazuh-secrets.yml"
-  pre_tasks:
-    - name: Load http_proxy vars if present
-      include_vars:
-        dir: "{{ playbook_dir }}/vars"
-        files_matching: "https_proxy.yml"
+# Certificates generation
+  - hosts: localhost
+    vars_files:
+      - "{{ playbook_dir }}/vars/wazuh-single.yml"
+      - "{{ playbook_dir }}/vars/wazuh-secrets.yml"
+    roles:
+      - role: "{{ playbook_dir }}/roles/wazuh-ansible/wazuh-ansible/roles/wazuh/wazuh-indexer"
+        perform_installation: false
+    become: no
+    #become_user: root
+    vars:
+      indexer_node_master: true
+      instances:
+        node1:
+          name: "{{ indexer_node_name }}"      # Important: must be equal to indexer_node_name.
+          ip: "{{ indexer_network_host }}"
+          role: indexer
+    tags:
+      - generate-certs
+# Single node
+  - hosts: wazuh-master
+    vars_files:
+       - "{{ playbook_dir }}/vars/wazuh-single.yml"
+    become: yes
+    become_user: root
+    roles:
+      - role: "{{ playbook_dir }}/roles/wazuh-ansible/wazuh-ansible/roles/wazuh/wazuh-indexer"
+      - role: "{{ playbook_dir }}/roles/wazuh-ansible/wazuh-ansible/roles/wazuh/ansible-wazuh-manager"
+      - role: "{{ playbook_dir }}/roles/wazuh-ansible/wazuh-ansible/roles/wazuh/ansible-filebeat-oss"
+      - role: "{{ playbook_dir }}/roles/wazuh-ansible/wazuh-ansible/roles/wazuh/wazuh-dashboard"
+    vars:
+      single_node: true
+      minimum_master_nodes: 1
+      indexer_node_master: true
+      indexer_network_host: "{{ indexer_network_host }}"
+      filebeat_node_name: "{{ indexer_node_name }}"
+      filebeat_output_indexer_hosts:
+      - "{{ indexer_network_host }}"
+      instances:
+        node1:
+          name: "{{ indexer_node_name }}"       # Important: must be equal to indexer_node_name.
+          ip: "{{ indexer_network_host }}"
+          role: indexer
+      ansible_shell_allow_world_readable_temp: true
 
-    - name: Locally install packages required for opendistro cert generation
-      package:
-        name:
-          - curl
-          - unzip
-          - wget
-          - libcap
-          - java-11-openjdk-devel
-        state: present
-      delegate_to: localhost
-      when: ansible_os_family == 'RedHat'
+      post_tasks:
+        - name: Set http/s_proxy vars in ossec-init.conf for vulnerability detector
+          blockinfile:
+            path: "/var/ossec/etc/ossec.conf"
+            state: present
+            owner: root
+            group: ossec
+            block: |
+              HTTPS_PROXY={{ http_proxy_url }}
+              HTTP_PROXY={{ http_proxy_url }}
+            backup: yes
+          when: http_proxy_url is defined
+          notify:
+            - Restart wazuh
 
-  roles:
-    - "{{ playbook_dir }}/roles/wazuh-ansible/wazuh-ansible/roles/opendistro/opendistro-elasticsearch"
-    - "{{ playbook_dir }}/roles/wazuh-ansible/wazuh-ansible/roles/wazuh/ansible-wazuh-manager"
-    - "{{ playbook_dir }}/roles/wazuh-ansible/wazuh-ansible/roles/wazuh/ansible-filebeat-oss"
-    - "{{ playbook_dir }}/roles/wazuh-ansible/wazuh-ansible/roles/opendistro/opendistro-kibana"
+    handlers:
+      - name: Restart wazuh
+        service:
+          name: wazuh-manager
+          state: restarted
 
-  post_tasks:
-    - name: Set http/s_proxy vars in ossec-init.conf for vulnerability detector
-      blockinfile:
-        path: "/etc/ossec-init.conf"
-        state: present
-        owner: root
-        group: ossec
-        block: |
-          HTTPS_PROXY={{ http_proxy_url }}
-          HTTP_PROXY={{ http_proxy_url }}
-        backup: yes
-      when: http_proxy_url is defined
-      notify:
-        - Restart wazuh
-
-    - name: Check for elasticsearch performance analyser
-      command:
-        cmd: /usr/share/elasticsearch/bin/elasticsearch-plugin list
-      changed_when: no
-      register: elasticsearch_plugins
-
-    - name: Remove elasticsearch performance analyser
-      command:
-        cmd: /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_performance_analyzer
-      when: "'opendistro_performance_analyzer' in elasticsearch_plugins.stdout"
-      notify:
-        - Restart elasticsearch
-
-    - name: Include elasticsearch custom vars
-      include_vars:
-        file: "{{ playbook_dir }}/vars/elasticsearch-custom.yml"
-
-    - name: Add custom elasticsearch users
-      blockinfile:
-        path: "{{ opendistro_sec_plugin_conf_path }}/internal_users.yml"
-        state: present
-        owner: root
-        group: elasticsearch
-        block: "{{ elasticsearch_custom_internal_users }}"
-        backup: yes
-      when: elasticsearch_custom_internal_users is defined
-      notify:
-        - Apply elasticsearch custom vars
-        - Restart elasticsearch
-
-    - name: Add wazuh elasticsearch roles
-      blockinfile:
-        path: "{{ opendistro_sec_plugin_conf_path }}/roles.yml"
-        state: present
-        owner: root
-        group: elasticsearch
-        block: "{{ elasticsearch_custom_roles }}"
-        backup: yes
-      when: elasticsearch_custom_roles is defined
-      notify:
-        - Apply elasticsearch custom vars
-        - Restart elasticsearch
-
-    - name: Add wazuh elasticsearch roles mapping
-      blockinfile:
-        path: "{{ opendistro_sec_plugin_conf_path }}/roles_mapping.yml"
-        state: present
-        owner: root
-        group: elasticsearch
-        block: "{{ elasticsearch_custom_roles_mapping }}"
-        backup: yes
-      when: elasticsearch_custom_roles_mapping is defined
-      notify:
-        - Apply elasticsearch custom vars
-        - Restart elasticsearch
-
-    - name: Fix Kibana multitenancy config
-      lineinfile:
-        path: "{{ kibana_conf_path }}/kibana.yml"
-        regexp: '^opendistro_security\.multitenancy\.enabled:'
-        line: 'opendistro_security.multitenancy.enabled: true'
-      notify:
-        - Restart kibana
-
-  handlers:
-    - name: Apply elasticsearch custom vars
-      command: >-
-        {{ opendistro_sec_plugin_tools_path }}/securityadmin.sh
-        -cacert {{ opendistro_conf_path }}/root-ca.pem
-        -cert {{ opendistro_conf_path }}/admin.pem
-        -key {{ opendistro_conf_path }}/admin.key
-        -cd {{ opendistro_sec_plugin_conf_path }}/
-        -nhnv -icl
-        -h {{ elasticsearch_network_host }}
-      run_once: true
-
-    - name: Restart elasticsearch
-      service:
-        name: elasticsearch
-        state: restarted
-
-    - name: Restart kibana
-      service:
-        name: kibana
-        state: restarted
-
-    - name: Restart wazuh
-      service:
-        name: wazuh-manager
-        state: restarted

--- a/wazuh-manager.yml
+++ b/wazuh-manager.yml
@@ -1,67 +1,44 @@
 ---
 # Certificates generation
-  - hosts: localhost
-    vars_files:
-      - "{{ playbook_dir }}/vars/wazuh-single.yml"
-      - "{{ playbook_dir }}/vars/wazuh-secrets.yml"
-    roles:
-      - role: "{{ playbook_dir }}/roles/wazuh-ansible/wazuh-ansible/roles/wazuh/wazuh-indexer"
-        perform_installation: false
-    become: no
-    #become_user: root
-    vars:
-      indexer_node_master: true
-      instances:
-        node1:
-          name: "{{ indexer_node_name }}"      # Important: must be equal to indexer_node_name.
-          ip: "{{ indexer_network_host }}"
-          role: indexer
-    tags:
-      - generate-certs
+- hosts: localhost
+  vars_files:
+    - "{{ playbook_dir }}/vars/wazuh-single.yml"
+    - "{{ playbook_dir }}/vars/wazuh-secrets.yml"
+  roles:
+    - role: "{{ playbook_dir }}/roles/wazuh-ansible/wazuh-ansible/roles/wazuh/wazuh-indexer"
+      perform_installation: false
+  become: no
+  #become_user: root
+  tags:
+    - generate-certs
 # Single node
-  - hosts: wazuh-master
-    vars_files:
-       - "{{ playbook_dir }}/vars/wazuh-single.yml"
-    become: yes
-    become_user: root
-    roles:
-      - role: "{{ playbook_dir }}/roles/wazuh-ansible/wazuh-ansible/roles/wazuh/wazuh-indexer"
-      - role: "{{ playbook_dir }}/roles/wazuh-ansible/wazuh-ansible/roles/wazuh/ansible-wazuh-manager"
-      - role: "{{ playbook_dir }}/roles/wazuh-ansible/wazuh-ansible/roles/wazuh/ansible-filebeat-oss"
-      - role: "{{ playbook_dir }}/roles/wazuh-ansible/wazuh-ansible/roles/wazuh/wazuh-dashboard"
-    vars:
-      single_node: true
-      minimum_master_nodes: 1
-      indexer_node_master: true
-      indexer_network_host: "{{ indexer_network_host }}"
-      filebeat_node_name: "{{ indexer_node_name }}"
-      filebeat_output_indexer_hosts:
-      - "{{ indexer_network_host }}"
-      instances:
-        node1:
-          name: "{{ indexer_node_name }}"       # Important: must be equal to indexer_node_name.
-          ip: "{{ indexer_network_host }}"
-          role: indexer
-      ansible_shell_allow_world_readable_temp: true
-
-      post_tasks:
-        - name: Set http/s_proxy vars in ossec-init.conf for vulnerability detector
-          blockinfile:
-            path: "/var/ossec/etc/ossec.conf"
-            state: present
-            owner: root
-            group: ossec
-            block: |
-              HTTPS_PROXY={{ http_proxy_url }}
-              HTTP_PROXY={{ http_proxy_url }}
-            backup: yes
-          when: http_proxy_url is defined
-          notify:
-            - Restart wazuh
-
-    handlers:
-      - name: Restart wazuh
-        service:
-          name: wazuh-manager
-          state: restarted
+- hosts: wazuh-master
+  vars_files:
+     - "{{ playbook_dir }}/vars/wazuh-single.yml"
+  become: yes
+  become_user: root
+  roles:
+    - role: "{{ playbook_dir }}/roles/wazuh-ansible/wazuh-ansible/roles/wazuh/wazuh-indexer"
+    - role: "{{ playbook_dir }}/roles/wazuh-ansible/wazuh-ansible/roles/wazuh/ansible-wazuh-manager"
+    - role: "{{ playbook_dir }}/roles/wazuh-ansible/wazuh-ansible/roles/wazuh/ansible-filebeat-oss"
+    - role: "{{ playbook_dir }}/roles/wazuh-ansible/wazuh-ansible/roles/wazuh/wazuh-dashboard"  
+  post_tasks:
+    - name: Set http/s_proxy vars in ossec-init.conf for vulnerability detector
+      blockinfile:
+        path: "/var/ossec/etc/ossec.conf"
+        state: present
+        owner: root
+        group: ossec
+        block: |
+          HTTPS_PROXY={{ http_proxy_url }}
+          HTTP_PROXY={{ http_proxy_url }}
+        backup: yes
+      when: http_proxy_url is defined
+      notify:
+        - Restart wazuh
+  handlers:
+    - name: Restart wazuh
+      service:
+        name: wazuh-manager
+        state: restarted
 


### PR DESCRIPTION
This PR consist with updated wazuh deployment to version 4.3.10. Main change in wazuh since version 4.1, was replacing Elasticsearch/opendistro and Kibana with wazuh-indexer and wazuh-dashboard. I am not 100% sure if we want to simply update release those files. IMHO it would be better to leave them for future reference and add content from this PR as separate files. On the other hand you can always get it from history, if you really want to. 
