### PR TITLE
Fix Ansible error when group is not defined

### DIFF
--- a/cloudkitty-ratings-field-mappings.yml
+++ b/cloudkitty-ratings-field-mappings.yml
@@ -25,7 +25,7 @@
 - name: Create hashmap field mappings
   vars:
     field_id: "{{ (hashmap_field.stdout | from_json | selectattr('Name', 'equalto', field.name) | first)['Field ID'] }}"
-    group_id: "{{ (hashmap_groups.stdout | from_json | selectattr('Name', 'equalto', item.group) | first)['Group ID'] | default('') }}"
+    group_id: "{{ (hashmap_groups.stdout | from_json | selectattr('Name', 'equalto', item.group) | first)['Group ID'] | default('') if item.group is defined else '' }}"
   command: >
     {{ openstack }} rating hashmap mapping create
     {{ item.cost }}

--- a/cloudkitty-ratings.yml
+++ b/cloudkitty-ratings.yml
@@ -151,7 +151,7 @@
         mappings_result: "{{ hashmap_mappings.results | selectattr('item', 'equalto', item.service) | first }}"
         mappings: "{{ mappings_result.stdout | from_json }}"
         service_id: "{{ (hashmap_services.stdout | from_json | selectattr('Name', 'equalto', item.service) | first)['Service ID'] }}"
-        group_id: "{{ (hashmap_groups.stdout | from_json | selectattr('Name', 'equalto', item.group) | first)['Group ID'] | default('') }}"
+        group_id: "{{ (hashmap_groups.stdout | from_json | selectattr('Name', 'equalto', item.group) | first)['Group ID'] | default('') if item.group is defined else '' }}"
       command: >
         {{ openstack }} rating hashmap mapping create
         {{ item.cost }}


### PR DESCRIPTION
The playbook failed with:

    The task includes an option with an undefined variable. The error
    was: {{ (hashmap_groups.stdout | from_json | selectattr('Name',
    'equalto', item.group) | first)['Group ID'] | default('') }}: 'dict
    object' has no attribute 'group'