### PR TITLE
Handle undefined env vars in reboot.yml

### DIFF
--- a/reboot.yml
+++ b/reboot.yml
@@ -1,7 +1,7 @@
 ---
 - name: Reboot the host
   hosts: seed-hypervisor:seed:overcloud:infra-vms
-  serial: "{{ lookup('env', 'ANSIBLE_SERIAL') | default(0) }}"
+  serial: "{{ lookup('env', 'ANSIBLE_SERIAL') | default(0, true) }}"
   tags:
     - reboot
   tasks:


### PR DESCRIPTION
When ANSIBLE_SERIAL env varaible is not defined, running the reboot playbook results in
ERROR! Unexpected Exception, this is probably a bug: invalid literal for int() with base 10: '' This is because lookup function will return an empty string even if variable does not exist.

We allow the default filter to account for the lookup call evaluating to an empty string by setting the second parameter to true [1].

1. https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_filters.html#providing-default-values